### PR TITLE
fix: cli: typo in sample config

### DIFF
--- a/client/packages/cli/src/config.rs
+++ b/client/packages/cli/src/config.rs
@@ -120,7 +120,7 @@ port = 5000
 # - alt_triggers
 # - rear_touchpad
 # - front_touchpad
-config = "standart"
+configuration = "standart"
 
 # Polling interval in microseconds
 polling_interval = 6000


### PR DESCRIPTION
It was broken because of a18742ecb774bbb074c0a1a93dd6d01839da0122

This should make it load configuration correctly